### PR TITLE
Fix evaluation error for guard stacks

### DIFF
--- a/evaluation.js
+++ b/evaluation.js
@@ -84,10 +84,10 @@ function Ev(stack,r,c,rK,bK){
              + Math.max( 0, pieceVal(top,r,c)+ (isRed(top) ? 1 : -1) * lambda*Ev(below,r,c,rK,bK)))
   }
   else{
-    return (isRed(top) ? 1 : -1) 
-           * ( controlScore(top,r,c,rK,bK) 
+    return (isRed(top) ? 1 : -1)
+           * ( controlScore(top,r,c,rK,bK)
              + pieceVal(top,r,c)
-             + lambda * Math.max( 0, Array.from({length: below.length}, (_, i) => (isRed(top) ? 1 : -1) *Ev(below.slice(i),r,c,rK,bK))))
+             + lambda * Math.max( 0, ...below.map((_, i) => (isRed(top) ? 1 : -1) * Ev(below.slice(i), r, c, rK, bK))))
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure guard stacks evaluate correctly when multiple pieces are beneath

## Testing
- `node -e "const fs=require('fs');const vm=require('vm');const board=[['士\n象\n車','','',''],['','','',''],['','','',''],['','','',''],['','','',''],['','','',''],['','','','帥'],['','','','將']];const context={board,rowNo:8,colNo:4,KingTakeKing:true,isRed:c=>/[帥兵俥傌炮相仕]/.test(c),isBlack:c=>/[將卒車馬包象士]/.test(c),height:(x,y)=>board[x][y].split('\\n').length,console};vm.createContext(context);vm.runInContext(fs.readFileSync('evaluation.js','utf8'),context);console.log('evaluation',context.evaluateBoard());"`


------
https://chatgpt.com/codex/tasks/task_b_68ab2abf482c8331a7e3dc11e4407c66